### PR TITLE
Allow renovate and dependabot to start demos

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -82,7 +82,10 @@ def github_demo_webhook():
     repo = ghub.repository(repo_owner, repo_name)
 
     # Only trigger builds if PR author is a collaborator
-    if not repo.is_collaborator(author):
+    allowed_bots = ["renovate[bot]", "dependabot[bot]"]
+    allowed = author in allowed_bots or repo.is_collaborator(author)
+    
+    if not allowed:
         message = f"{author} is not a collaborator of the repo"
 
         # If the PR was opened post the error message


### PR DESCRIPTION
I can't test this because it's too much work. Hopefully the code is straightforward enough that it will *just work*.

I did check the login names for the bots by looking at the JSON response for 2 PRs. Hopefully this is a reliable test:

https://api.github.com/repos/canonical/ubuntu.com/pulls/11558
https://api.github.com/repos/canonical/ubuntu.com/pulls/11843

Fixes https://github.com/canonical/web-design-systems-squad/issues/57