### PR TITLE
Add github-actions[bot] as an allowed author

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -82,7 +82,7 @@ def github_demo_webhook():
     repo = ghub.repository(repo_owner, repo_name)
 
     # Only trigger builds if PR author is a collaborator
-    allowed_bots = ["renovate[bot]", "dependabot[bot]"]
+    allowed_bots = ["renovate[bot]", "dependabot[bot]", "github-actions[bot]"]
     allowed = author in allowed_bots or repo.is_collaborator(author)
     
     if not allowed:


### PR DESCRIPTION
## Done

* added github-actions[bot] to allowed bots that can trigger a start/stop in jenkins

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8100
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)