### PR TITLE
Fixed Jenkins url formatting

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -108,17 +108,18 @@ def github_demo_webhook():
     remote_build_url = (
         f"http://{JENKINS_URL}/{jenkins_job}/buildWithParameters?{jenkins_job_params}"
     )
+    job_id = ""
 
     # Trigger the build in jenkins
     if not app.debug:
         response = requests.get(remote_build_url)
         response.raise_for_status()
+        # Get the id of the demo
+        job_id = response.headers.get("Location").split("/")[-2]
     else:
         # In debug mode just print the URL
-        print(remote_build_url)
-
-    # Get the id of the demo
-    job_id = response.headers.get("Location").split("/")[-2]
+        app.logger.info(remote_build_url)
+        app.logger.info(job_id)
 
     # If the PR was opened post the the link to the demo
     if action == "opened":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -117,10 +117,13 @@ def github_demo_webhook():
         # In debug mode just print the URL
         print(remote_build_url)
 
+    # Get the id of the demo
+    job_id = response.headers.get("Location").split("/")[-2]
+
     # If the PR was opened post the the link to the demo
     if action == "opened":
         demo_url = f"https://{repo_name.replace('.', '-')}-{pull_request}.demos.haus"
-        jenkins_url = f"{JENKINS_PUBLIC_URL}/job/{jenkins_job}/"
+        jenkins_url = f"{JENKINS_PUBLIC_URL}/{jenkins_job}/{job_id}"
 
         comment = f"### [<img src='https://assets.ubuntu.com/v1/6baef514-ubuntu-circle-of-friends-large.svg' height=32 width=32> Demo</img>]({demo_url})\n"
         comment += f"### [<img src='https://assets.ubuntu.com/v1/e512b0e2-jenkins.svg' height=32 width=32> Jenkins </img>]({jenkins_url})\n"


### PR DESCRIPTION
## Done

- Fixed URL format for Jenkins demos

## QA

- Create a new PR on [webteam.canonical.com](https://github.com/canonical/webteam.canonical.com)
  - Check that the comment on the PR has working links 